### PR TITLE
Add label marker webhook and all application code structure

### DIFF
--- a/cmd/k8s-webhook-example/config.go
+++ b/cmd/k8s-webhook-example/config.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"os"
+
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+// CmdConfig represents the configuration of the command.
+type CmdConfig struct {
+	Debug           bool
+	Development     bool
+	ListenAddr      string
+	MetricsPath     string
+	TLSCertFilePath string
+	TLSKeyFilePath  string
+	LabelMarks      map[string]string
+}
+
+// NewCmdConfig returns a new command configuration.
+func NewCmdConfig() (*CmdConfig, error) {
+	c := &CmdConfig{
+		LabelMarks: map[string]string{},
+	}
+	app := kingpin.New("k8s-webhook-example", "A Kubernetes production-ready admission webhook example.")
+	app.Version(Version)
+
+	app.Flag("debug", "Enable debug mode.").BoolVar(&c.Debug)
+	app.Flag("development", "Enable development mode.").BoolVar(&c.Development)
+	app.Flag("listen-address", "the address where the HTTP server will be listening.").Default(":8080").StringVar(&c.ListenAddr)
+	app.Flag("metrics-path", "the path where Prometheus metrics will be served.").Default("/metrics").StringVar(&c.MetricsPath)
+	app.Flag("tls-cert-file-path", "the path for the webhook HTTP server TLS cert file.").StringVar(&c.TLSCertFilePath)
+	app.Flag("tls-key-file-path", "the path for the webhook HTTP server TLS key file.").StringVar(&c.TLSKeyFilePath)
+	app.Flag("webhook-label-marks", "the marks the webhook will set to all resources, if no marks, the label marker webhook will be disabled .").Short('l').StringMapVar(&c.LabelMarks)
+
+	_, err := app.Parse(os.Args[1:])
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}

--- a/cmd/k8s-webhook-example/main.go
+++ b/cmd/k8s-webhook-example/main.go
@@ -1,7 +1,158 @@
 package main
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/pprof"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/oklog/run"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/slok/k8s-webhook-example/internal/http/webhook"
+	"github.com/slok/k8s-webhook-example/internal/log"
+	"github.com/slok/k8s-webhook-example/internal/mark"
+	internalprometheus "github.com/slok/k8s-webhook-example/internal/metrics/prometheus"
+)
+
+var (
+	// Version is set at compile time.
+	Version = "dev"
+)
+
+func runApp() error {
+	cfg, err := NewCmdConfig()
+	if err != nil {
+		return fmt.Errorf("could not get commandline configuration: %w", err)
+	}
+
+	// Set up logger.
+	logrusLog := logrus.New()
+	logrusLogEntry := logrus.NewEntry(logrusLog).WithField("app", "k8s-webhook-example")
+	if cfg.Debug {
+		logrusLogEntry.Logger.SetLevel(logrus.DebugLevel)
+	}
+	if !cfg.Development {
+		logrusLogEntry.Logger.SetFormatter(&logrus.JSONFormatter{})
+	}
+	logger := log.NewLogrus(logrusLogEntry).WithKV(log.KV{"version": Version})
+
+	// Dependencies.
+	metricsRec := internalprometheus.NewRecorder(prometheus.DefaultRegisterer)
+
+	var marker mark.Marker
+	if len(cfg.LabelMarks) > 0 {
+		marker = mark.NewLabelMarker(cfg.LabelMarks)
+		logger.Infof("label marker webhook enabled")
+	} else {
+		marker = mark.DummyMarker
+		logger.Warningf("label marker webhook disabled")
+	}
+
+	// Prepare run entrypoints.
+	var g run.Group
+
+	// OS signals.
+	{
+		sigC := make(chan os.Signal, 1)
+		exitC := make(chan struct{})
+		signal.Notify(sigC, syscall.SIGTERM, syscall.SIGINT)
+
+		g.Add(
+			func() error {
+				select {
+				case s := <-sigC:
+					logger.Infof("signal %s received", s)
+					return nil
+				case <-exitC:
+					return nil
+				}
+			},
+			func(_ error) {
+				close(exitC)
+			},
+		)
+	}
+
+	// HTTP server.
+	{
+		logger := logger.WithKV(log.KV{"addr": cfg.ListenAddr})
+		mux := http.NewServeMux()
+
+		// Metrics.
+		mux.Handle(cfg.MetricsPath, promhttp.Handler())
+
+		// Pprof.
+		mux.HandleFunc("/debug/pprof/", pprof.Index)
+		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+		// Health checks.
+		hcHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+		mux.HandleFunc("/healthz/ready", hcHandler)
+		mux.HandleFunc("/healthz/live", hcHandler)
+
+		// Webhook.
+		wh, err := webhook.New(webhook.Config{
+			Marker:          marker,
+			MetricsRecorder: metricsRec,
+			Logger:          logger,
+		})
+		if err != nil {
+			return fmt.Errorf("could not create webhooks handler: %w", err)
+		}
+		mux.Handle("/", wh)
+
+		server := http.Server{Addr: cfg.ListenAddr, Handler: mux}
+		g.Add(
+			func() error {
+				if cfg.TLSCertFilePath == "" || cfg.TLSKeyFilePath == "" {
+					logger.Warningf("webhook running without TLS")
+					logger.Infof("http server listening...")
+					return server.ListenAndServe()
+				}
+
+				logger.Infof("https server listening...")
+				return server.ListenAndServeTLS(cfg.TLSCertFilePath, cfg.TLSKeyFilePath)
+			},
+			func(_ error) {
+				logger.Infof("start draining connections")
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+
+				err := server.Shutdown(ctx)
+				if err != nil {
+					logger.Errorf("error while shutting down the server: %s", err)
+				} else {
+					logger.Infof("server stopped")
+				}
+			},
+		)
+	}
+
+	err = g.Run()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
 
 func main() {
-	fmt.Println("hello world")
+	err := runApp()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error running app: %s", err)
+		os.Exit(1)
+	}
+
+	os.Exit(0)
 }

--- a/internal/http/webhook/handler.go
+++ b/internal/http/webhook/handler.go
@@ -1,0 +1,36 @@
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/slok/k8s-webhook-example/internal/log"
+	whhttp "github.com/slok/kubewebhook/pkg/http"
+	mutatingwh "github.com/slok/kubewebhook/pkg/webhook/mutating"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// allmark sets up the webhook handler for marking all kubernetes resources using Kubewebhook library.
+func (h handler) allMark() (http.Handler, error) {
+	mt := mutatingwh.MutatorFunc(func(ctx context.Context, obj metav1.Object) (bool, error) {
+		err := h.marker.Mark(ctx, obj)
+		if err != nil {
+			return false, fmt.Errorf("could not mark the resource: %w", err)
+		}
+
+		return false, nil
+	})
+
+	logger := h.logger.WithKV(log.KV{"lib": "kubewebhook", "webhook": "allMark"})
+	wh, err := mutatingwh.NewWebhook(mutatingwh.WebhookConfig{Name: "allMark"}, mt, nil, h.metrics, logger)
+	if err != nil {
+		return nil, fmt.Errorf("could not create webhook: %w", err)
+	}
+	whHandler, err := whhttp.HandlerFor(wh)
+	if err != nil {
+		return nil, fmt.Errorf("could not create handler from webhook: %w", err)
+	}
+
+	return whHandler, nil
+}

--- a/internal/http/webhook/metrics.go
+++ b/internal/http/webhook/metrics.go
@@ -1,0 +1,24 @@
+package webhook
+
+import (
+	gohttpmetrics "github.com/slok/go-http-metrics/metrics"
+	whmetrics "github.com/slok/kubewebhook/pkg/observability/metrics"
+)
+
+// MetricsRecorder is the service used to record metrics in the internal HTTP webhook.
+type MetricsRecorder interface {
+	gohttpmetrics.Recorder
+	whmetrics.Recorder
+}
+
+// Types used to avoid collisions with the same interface naming.
+type httpRecorder gohttpmetrics.Recorder
+type webhookRecorder whmetrics.Recorder
+
+var dummyMetricsRecorder = struct {
+	httpRecorder
+	webhookRecorder
+}{
+	httpRecorder:    gohttpmetrics.Dummy,
+	webhookRecorder: whmetrics.Dummy,
+}

--- a/internal/http/webhook/middleware.go
+++ b/internal/http/webhook/middleware.go
@@ -1,0 +1,14 @@
+package webhook
+
+import (
+	"net/http"
+
+	"github.com/slok/go-http-metrics/middleware"
+)
+
+// measuredHandler wraps a handler and measures the request handled
+// by this handler.
+func (h handler) measuredHandler(next http.Handler) http.Handler {
+	mdlw := middleware.New(middleware.Config{Recorder: h.metrics})
+	return mdlw.Handler("", next)
+}

--- a/internal/http/webhook/routes.go
+++ b/internal/http/webhook/routes.go
@@ -1,0 +1,16 @@
+package webhook
+
+import (
+	"net/http"
+)
+
+// routes wires the routes to handlers on a specific router.
+func (h handler) routes(router *http.ServeMux) error {
+	allmark, err := h.allMark()
+	if err != nil {
+		return err
+	}
+	router.Handle("/wh/mutating/allmark", allmark)
+
+	return nil
+}

--- a/internal/http/webhook/webhook.go
+++ b/internal/http/webhook/webhook.go
@@ -1,0 +1,75 @@
+package webhook
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/slok/k8s-webhook-example/internal/log"
+	"github.com/slok/k8s-webhook-example/internal/mark"
+)
+
+// Config is the handler configuration.
+type Config struct {
+	MetricsRecorder MetricsRecorder
+	Marker          mark.Marker
+	Logger          log.Logger
+}
+
+func (c *Config) defaults() error {
+	if c.Marker == nil {
+		return fmt.Errorf("marker is required")
+	}
+
+	if c.MetricsRecorder == nil {
+		c.MetricsRecorder = dummyMetricsRecorder
+	}
+
+	if c.Logger == nil {
+		c.Logger = log.Dummy
+	}
+
+	return nil
+}
+
+type handler struct {
+	handler http.Handler
+	marker  mark.Marker
+	metrics MetricsRecorder
+	logger  log.Logger
+}
+
+// New returns a new webhook handler.
+func New(config Config) (http.Handler, error) {
+	err := config.defaults()
+	if err != nil {
+		return nil, fmt.Errorf("handler configuration is not valid: %w", err)
+	}
+
+	mux := http.NewServeMux()
+
+	h := handler{
+		handler: mux,
+		marker:  config.Marker,
+		metrics: config.MetricsRecorder,
+		logger:  config.Logger.WithKV(log.KV{"service": "webhook-handler"}),
+	}
+
+	// Register all the routes with our router.
+	err = h.routes(mux)
+	if err != nil {
+		return nil, fmt.Errorf("could not register routes on handler: %w", err)
+	}
+
+	// Register middlware.
+	h.registerRootMiddleware()
+
+	return h, nil
+}
+
+func (h handler) registerRootMiddleware() {
+	h.handler = h.measuredHandler(h.handler) // Add metrics middleware.
+}
+
+func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.handler.ServeHTTP(w, r)
+}

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,0 +1,44 @@
+package log
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+// KV is a helper type for structured logging fields usage.
+type KV map[string]interface{}
+
+// Logger is the interface that the loggers used by the library will use.
+type Logger interface {
+	Infof(format string, args ...interface{})
+	Warningf(format string, args ...interface{})
+	Errorf(format string, args ...interface{})
+	Debugf(format string, args ...interface{})
+	WithKV(KV) Logger
+}
+
+// Dummy logger doesn't log anything.
+const Dummy = dummy(0)
+
+var _ Logger = Dummy
+
+type dummy int
+
+func (d dummy) Infof(format string, args ...interface{})    {}
+func (d dummy) Warningf(format string, args ...interface{}) {}
+func (d dummy) Errorf(format string, args ...interface{})   {}
+func (d dummy) Debugf(format string, args ...interface{})   {}
+func (d dummy) WithKV(KV) Logger                            { return d }
+
+type logger struct {
+	*logrus.Entry
+}
+
+// NewLogrus returns a new log.Logger for a logrus implementation.
+func NewLogrus(l *logrus.Entry) Logger {
+	return logger{Entry: l}
+}
+
+func (l logger) WithKV(kv KV) Logger {
+	newLogger := l.Entry.WithFields(logrus.Fields(kv))
+	return NewLogrus(newLogger)
+}

--- a/internal/mark/mark.go
+++ b/internal/mark/mark.go
@@ -1,0 +1,42 @@
+package mark
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Marker knows how to mark Kubernetes resources.
+type Marker interface {
+	Mark(ctx context.Context, obj metav1.Object) error
+}
+
+// NewLabelMarker returns a new marker that will mark with labels.
+func NewLabelMarker(marks map[string]string) Marker {
+	return labelmarker{marks: marks}
+}
+
+type labelmarker struct {
+	marks map[string]string
+}
+
+func (l labelmarker) Mark(_ context.Context, obj metav1.Object) error {
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
+	for k, v := range l.marks {
+		labels[k] = v
+	}
+
+	obj.SetLabels(labels)
+	return nil
+}
+
+// DummyMarker is a marker that doesn't do anything.
+var DummyMarker Marker = dummyMaker(0)
+
+type dummyMaker int
+
+func (dummyMaker) Mark(_ context.Context, _ metav1.Object) error { return nil }

--- a/internal/mark/mark_test.go
+++ b/internal/mark/mark_test.go
@@ -1,0 +1,81 @@
+package mark_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/slok/k8s-webhook-example/internal/mark"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestLabelMarkerMark(t *testing.T) {
+	tests := map[string]struct {
+		marks  map[string]string
+		obj    metav1.Object
+		expObj metav1.Object
+	}{
+		"Having a pod, the labels should be mutated.": {
+			marks: map[string]string{
+				"test1": "value1",
+				"test2": "value2",
+			},
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					Labels: map[string]string{
+						"test2": "old-value2",
+						"test3": "value3",
+					},
+				},
+			},
+			expObj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					Labels: map[string]string{
+						"test1": "value1",
+						"test2": "value2",
+						"test3": "value3",
+					},
+				},
+			},
+		},
+
+		"Having a service, the labels should be mutated.": {
+			marks: map[string]string{
+				"test1": "value1",
+				"test2": "value2",
+			},
+			obj: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+			},
+			expObj: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					Labels: map[string]string{
+						"test1": "value1",
+						"test2": "value2",
+					},
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			m := mark.NewLabelMarker(test.marks)
+
+			err := m.Mark(context.TODO(), test.obj)
+			require.NoError(err)
+
+			assert.Equal(test.expObj, test.obj)
+		})
+	}
+}

--- a/internal/metrics/prometheus/prometheus.go
+++ b/internal/metrics/prometheus/prometheus.go
@@ -1,0 +1,31 @@
+package prometheus
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	gohttpmetrics "github.com/slok/go-http-metrics/metrics"
+	gohttpmetricsprometheus "github.com/slok/go-http-metrics/metrics/prometheus"
+	whmetrics "github.com/slok/kubewebhook/pkg/observability/metrics"
+
+	"github.com/slok/k8s-webhook-example/internal/http/webhook"
+)
+
+// Types used to avoid collisions with the same interface naming.
+type httpRecorder gohttpmetrics.Recorder
+type webhookRecorder whmetrics.Recorder
+
+// Recorder satisfies multiple metrics recording interfaces using a Prometheus backend.
+type Recorder struct {
+	httpRecorder
+	webhookRecorder
+}
+
+// NewRecorder returns a new Prometheus Recorder.
+func NewRecorder(reg prometheus.Registerer) Recorder {
+	return Recorder{
+		httpRecorder:    gohttpmetricsprometheus.NewRecorder(gohttpmetricsprometheus.Config{Registry: reg}),
+		webhookRecorder: whmetrics.NewPrometheus(reg),
+	}
+}
+
+// Interface assertion.
+var _ webhook.MetricsRecorder = Recorder{}


### PR DESCRIPTION
This PR adds a webhook and all the stuff required to set up an HTTP webhook:

- main structure with the dependencies required to set up a production-ready HTTP server
- Metrics service decoupled from the implementation.
- HTTP handler creation.
- marker service as the application service for the label marker webhook.